### PR TITLE
[fix] Dockerfile의 Java 이미지 수정

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 COPY . .
 RUN ./gradlew clean build -x test
 
-FROM openjdk:21-slim
+FROM eclipse-temurin:21-jre
 WORKDIR /app
 COPY --from=builder /app/build/libs/*.jar app.jar
 ENTRYPOINT ["java", "-jar", "app.jar"]


### PR DESCRIPTION
## 🛰️ Issue Number
- #6 

## 🪐 작업 내용
Docker 이미지 빌드 중 openjdk 이미지를 가져오지 못하는 문제가 발생함.
따라서, openjdk 이미지를 temulin 이미지로 변경함.

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?